### PR TITLE
Adding .github repository

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -20,7 +20,7 @@ orgs.newOrg('eclipse-thingweb') {
     orgs.newRepo('.github') {
       allow_update_branch: false,
       default_branch: "main",
-      dependabot_security_updates_enabled: true,
+      dependabot_security_updates_enabled: false,
       description: "Project-level settings, resources and discussions",
       has_discussions: true,
       homepage: "https://thingweb.io",

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -16,7 +16,7 @@ orgs.newOrg('eclipse-thingweb') {
     two_factor_requirement: false,
     web_commit_signoff_required: false,
     has_discussions: true,
-    discussion_source_repository: ".github"
+    discussion_source_repository: ".github",
     email: "thingweb-dev@eclipse.org",
   },
   _repositories+:: [

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -17,6 +17,20 @@ orgs.newOrg('eclipse-thingweb') {
     web_commit_signoff_required: false,
   },
   _repositories+:: [
+    orgs.newRepo('.github') {
+      allow_update_branch: false,
+      default_branch: "main",
+      dependabot_security_updates_enabled: true,
+      description: "Project-level settings, resources and discussions",
+      has_discussions: true,
+      homepage: "https://thingweb.io",
+      topics+: [
+        "iot",
+        "web",
+        "organization"
+      ],
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('node-wot') {
       allow_update_branch: false,
       default_branch: "master",

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -17,7 +17,7 @@ orgs.newOrg('eclipse-thingweb') {
     web_commit_signoff_required: false,
     has_discussions: true,
     discussion_source_repository: ".github"
-    email: thingweb-dev@eclipse.org,
+    email: "thingweb-dev@eclipse.org",
   },
   _repositories+:: [
     orgs.newRepo('.github') {

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -5,7 +5,7 @@ orgs.newOrg('eclipse-thingweb') {
     default_repository_permission: "none",
     default_workflow_permissions: "write",
     dependabot_security_updates_enabled_for_new_repositories: false,
-    description: "",
+    description: "Components for making IoT solutions interoperable at scale by leveraging the W3C WoT standards, no matter if improving an existing solution or building a new one",
     members_can_change_project_visibility: false,
     members_can_change_repo_visibility: true,
     members_can_delete_repositories: true,
@@ -15,14 +15,15 @@ orgs.newOrg('eclipse-thingweb') {
     readers_can_create_discussions: true,
     two_factor_requirement: false,
     web_commit_signoff_required: false,
+    has_discussions: true,
+    discussion_source_repository: ".github"
+    email: thingweb-dev@eclipse.org,
   },
   _repositories+:: [
     orgs.newRepo('.github') {
-      allow_update_branch: false,
-      default_branch: "main",
       dependabot_security_updates_enabled: false,
       description: "Project-level settings, resources and discussions",
-      has_discussions: true,
+      has_discussions: false,
       homepage: "https://thingweb.io",
       topics+: [
         "iot",


### PR DESCRIPTION
As we have spoken on our friday calls, we decided to have a repository for project-level "stuff", which are:
- GitHub discussions for the whole project, mainly organizational
- GitHub organization landing page so that the project has a similar landing to https://github.com/nodejs
- Mirroring project description so that we can version it