### PR TITLE
Align wot-related topics across all repositories

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -28,7 +28,8 @@ orgs.newOrg('eclipse-thingweb') {
         "iot",
         "organization",
         "web",
-        "web-of-things"
+        "web-of-things",
+        "wot"
       ],
       web_commit_signoff_required: false,
       workflows+: {
@@ -50,6 +51,7 @@ orgs.newOrg('eclipse-thingweb') {
         "internetofthings",
         "iot",
         "webofthings",
+        "web-of-things",
         "wot"
       ],
       web_commit_signoff_required: false,
@@ -87,7 +89,8 @@ orgs.newOrg('eclipse-thingweb') {
         "iot",
         "nodejs",
         "web",
-        "web-of-things"
+        "web-of-things",
+        "wot"
       ],
       web_commit_signoff_required: false,
       workflows+: {
@@ -122,7 +125,8 @@ orgs.newOrg('eclipse-thingweb') {
         "iot",
         "nodejs",
         "web",
-        "web-of-things"
+        "web-of-things",
+        "wot"
       ],
       web_commit_signoff_required: false,
       workflows+: {
@@ -173,7 +177,8 @@ orgs.newOrg('eclipse-thingweb') {
         "iot",
         "protocols",
         "testing",
-        "web-of-things"
+        "web-of-things",
+        "wot"
       ],
       web_commit_signoff_required: false,
       workflows+: {
@@ -190,7 +195,8 @@ orgs.newOrg('eclipse-thingweb') {
         "iot",
         "organization",
         "web",
-        "web-of-things"
+        "web-of-things",
+        "wot"
       ],
       web_commit_signoff_required: false,
       workflows+: {
@@ -212,7 +218,8 @@ orgs.newOrg('eclipse-thingweb') {
       topics+: [
         "iot",
         "web",
-        "web-of-things"
+        "web-of-things",
+        "wot"
       ],
       web_commit_signoff_required: false,
       workflows+: {

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -50,7 +50,6 @@ orgs.newOrg('eclipse-thingweb') {
         "flutter",
         "internetofthings",
         "iot",
-        "webofthings",
         "web-of-things",
         "wot"
       ],


### PR DESCRIPTION
As discussed in today's [committer meeting](https://github.com/eclipse-thingweb/thingweb/wiki/Committer-Meeting-%E2%80%90-01.12.2023#action-items), this PR adds the topics `wot` and `web-of-things` to all of our repos that did not have them previously.

I wasn't sure if we said that the `webofthings` topic that is currently set for `dart_wot` should be replaced/removed – if so, then just let me know and I will update the PR accordingly :)