### PR TITLE
chore(otterdog): simplify node-wot protection rules

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -91,7 +91,7 @@ orgs.newOrg('eclipse-thingweb') {
       branch_protection_rules : [
         orgs.newBranchProtectionRule('master') {
           required_approving_review_count: 1,
-          bypass_actors+: [
+          bypass_pull_request_allowances+: [
             "@relu91",
             "@danielpeintner"
           ],

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -90,7 +90,11 @@ orgs.newOrg('eclipse-thingweb') {
       ],
       branch_protection_rules : [
         orgs.newBranchProtectionRule('master') {
-          required_approving_review_count: 2
+          required_approving_review_count: 1,
+          bypass_actors+: [
+            "@relu91",
+            "@danielpeintner"
+          ],
         }
       ],
       web_commit_signoff_required: false,


### PR DESCRIPTION
As discussed in #16 this PR simplify the protection rules and adds @danielpeintner and me as actors capable of bypassing the rule. I couldn't find a way to define a group (which is more future-proof), but for now, I would say it is sufficient. 