### PR TITLE
Allow bypassing branch protection for dart_wot

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -62,7 +62,7 @@ orgs.newOrg('eclipse-thingweb') {
           bypass_pull_request_allowances+: [
             "@JKRhb",
           ],
-          required_approving_review_count: null,
+          required_approving_review_count: 1,
           required_status_checks+: [
             "build (macos-latest)",
             "build (ubuntu-latest)",

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -59,6 +59,9 @@ orgs.newOrg('eclipse-thingweb') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
+          bypass_pull_request_allowances+: [
+            "@JKRhb",
+          ],
           required_approving_review_count: null,
           required_status_checks+: [
             "build (macos-latest)",

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -53,6 +53,9 @@ orgs.newOrg('eclipse-thingweb') {
         default_workflow_permissions: "write",
       },
       secrets: [
+        orgs.newRepoSecret('BOT_TOKEN') {
+          value: "pass:bots/iot.thingweb/github.com/project-token",
+        },
         orgs.newRepoSecret('CODECOV_TOKEN') {
           value: "pass:bots/iot.thingweb/codecov.io/codecov-token",
         },

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -68,7 +68,7 @@ orgs.newOrg('eclipse-thingweb') {
             "build (ubuntu-latest)",
             "build (windows-latest)"
           ],
-          requires_pull_request: false,
+          requires_pull_request: true,
           requires_strict_status_checks: true,
         },
       ],


### PR DESCRIPTION
For dart_wot, I want to automate the release procedure and let GitHub Actions automatically generate new release notes and bump the version number of the package. However, for security reasons, apparently you need to add a personal access token to actually let the GitHub Actions workflows run for Pull Requests, causing the PRs to not be mergable in the current setup due to required checks that don't get triggered.

As a quick workaround, this PR would give me privileges to bypass the branch protection rules if needed. I would revert this change once I have a personal access token in place that can be used for this purpose. By the way: Are there any best practices to create personal access tokens for Eclipse Projects?

Thanks a lot :)

