### PR TITLE
Set number of required approvals for dart_wot to 0

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -62,9 +62,6 @@ orgs.newOrg('eclipse-thingweb') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          bypass_pull_request_allowances+: [
-            "@JKRhb",
-          ],
           required_approving_review_count: 0,
           required_status_checks+: [
             "build (macos-latest)",

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -65,7 +65,7 @@ orgs.newOrg('eclipse-thingweb') {
           bypass_pull_request_allowances+: [
             "@JKRhb",
           ],
-          required_approving_review_count: 1,
+          required_approving_review_count: 0,
           required_status_checks+: [
             "build (macos-latest)",
             "build (ubuntu-latest)",


### PR DESCRIPTION
As discussed in https://github.com/eclipse-thingweb/dart_wot/pull/148, this PR sets the number of required approvals to 0 for the `dart_wot` repository.