### PR TITLE
Adding new repo to manage common infrastructure

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -85,6 +85,24 @@ orgs.newOrg('eclipse-thingweb') {
         },
       ],
     },
+    orgs.newRepo('infrastructure') {
+      allow_merge_commit: true,
+      delete_branch_on_merge: false,
+      description: "Main infrastructure configuration of the server to manage the deployment of vserver.",
+      has_discussions: false,
+      homepage: "https://thingweb.io",
+      topics+: [
+        "iot",
+        "organization",
+        "web",
+        "web-of-things",
+        "wot"
+      ],
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+    },
     orgs.newRepo('node-red') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
As discussed in the call today, it would be better to have a common infrastructure configuration and use portainer stacks instead of each repo trying to build an infrastructure file. Thus, https://github.com/eclipse-thingweb/test-things/blob/main/docker-compose-infra.yml can be moved to a new repo, which is this one that is being created. As subrepos, we will have test-things, node-wot (for counter) and domus in the future. https://github.com/eclipse-thingweb/thingweb/blob/main/server/README.md#open-ports can be also moved here.