### PR TITLE
Fork WoT Application Manger repository

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -278,7 +278,7 @@ orgs.newOrg('eclipse-thingweb') {
       workflows+: {
        default_workflow_permissions: "write",
       },
-    }
+    },
     orgs.newRepo('website') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -259,6 +259,26 @@ orgs.newOrg('eclipse-thingweb') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('wam') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      forked_repository: "https://github.com/UniBO-PRISMLab/wam",
+      fork_default_branch_only: true,
+      description: "WoT Application Manager - a command line interface to build a Web of Things applications",
+      homepage: "https://thingweb.io",
+      has_wiki: false,
+      topics+: [
+        "iot",
+        "nodejs",
+        "web",
+        "web-of-things",
+        "wot"
+      ],
+      web_commit_signoff_required: false,
+      workflows+: {
+       default_workflow_permissions: "write",
+      },
+    }
     orgs.newRepo('website') {
       allow_merge_commit: true,
       allow_update_branch: false,

--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -262,7 +262,7 @@ orgs.newOrg('eclipse-thingweb') {
     orgs.newRepo('wam') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      forked_repository: "https://github.com/UniBO-PRISMLab/wam",
+      forked_repository: "UniBO-PRISMLab/wam",
       fork_default_branch_only: true,
       description: "WoT Application Manager - a command line interface to build a Web of Things applications",
       homepage: "https://thingweb.io",


### PR DESCRIPTION
As discussed during the past committers meeting this PR forks https://github.com/UniBO-PRISMLab/wam as a mean to expand our ecosystem of tools and facilities. 

Note that I disabled the wiki even if it was present in the original repository. I did it because I prefer to re-use that content in a new form inside the new website. 