### PR TITLE
Removing wotpy repo

### DIFF
--- a/otterdog/eclipse-thingweb.jsonnet
+++ b/otterdog/eclipse-thingweb.jsonnet
@@ -430,31 +430,5 @@ orgs.newOrg('iot.thingweb', 'eclipse-thingweb') {
         },
       ],
     },
-    orgs.newRepo('wotpy') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      default_branch: "main",
-      delete_branch_on_merge: false,
-      dependabot_security_updates_enabled: true,
-      description: "A WoT runtime in Python for Thing and Consumer applications",
-      has_wiki: false,
-      homepage: "https://thingweb.io",
-      topics+: [
-        "iot",
-        "python",
-        "web",
-        "web-of-things",
-        "wot"
-      ],
-      web_commit_signoff_required: false,
-      workflows+: {
-        default_workflow_permissions: "write",
-      },
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('master') {
-          required_approving_review_count: 1,
-        },
-      ],
-    },
   ],
 }


### PR DESCRIPTION
Removed configuration for 'wotpy' repository. We now have https://github.com/eclipse-thingweb/wot-py and need to do further configurations. Probably better to delete first.